### PR TITLE
Add Gemini and Spec Kit devcontainer features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,11 @@
 {
 	"image": "ghcr.io/jaredchurch/base:v3",
 	"features": {
-		"./features/opencode": {}
+		"./features/opencode": {},
+		"./features/gemini": {},
+		"./features/spec-kit": {}
 	},
+	"onCreateCommand": "env",
 	"containerEnv": {
 		"LANG": "en_NZ.UTF-8",
 		"LC_ALL": "en_NZ.UTF-8"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
 		"./features/gemini": {},
 		"./features/spec-kit": {}
 	},
-	"onCreateCommand": "env",
 	"containerEnv": {
 		"LANG": "en_NZ.UTF-8",
 		"LC_ALL": "en_NZ.UTF-8"

--- a/.devcontainer/features/gemini/devcontainer-feature.json
+++ b/.devcontainer/features/gemini/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+  "id": "gemini",
+  "version": "1.0.0",
+  "name": "Google Gemini",
+  "description": "Install Google Gemini"
+}

--- a/.devcontainer/features/gemini/install.sh
+++ b/.devcontainer/features/gemini/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# refer: https://github.com/github/spec-kit
+
+# export DEBIAN_FRONTEND=noninteractive
+
+if [ ! -x "$(command -v node)" ] || [ ! -x "$(command -v npm)" ]; then
+  echo "Node.js and npm are not installed. Installing them first..."
+  DEBIAN_FRONTEND=noninteractive apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install nodejs npm -y
+fi
+
+npm install -g @google/gemini-cli
+echo "✅ Install Gemini"
+
+### End of File

--- a/.devcontainer/features/opencode/install.sh
+++ b/.devcontainer/features/opencode/install.sh
@@ -3,8 +3,8 @@ set -e
 
 if [ ! -x "$(command -v node)" ] || [ ! -x "$(command -v npm)" ]; then
   echo "Node.js and npm are not installed. Installing them first..."
-  sudo DEBIAN_FRONTEND=noninteractive apt-get update
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install nodejs npm -y
+  DEBIAN_FRONTEND=noninteractive apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install nodejs npm -y
 fi
 
 if [ -x "$(command -v opencode)" ]; then

--- a/.devcontainer/features/spec-kit/devcontainer-feature.json
+++ b/.devcontainer/features/spec-kit/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+  "id": "spec-kit",
+  "version": "1.0.0",
+  "name": "Spec Kit",
+  "description": "Install Spec Kit"
+}

--- a/.devcontainer/features/spec-kit/install.sh
+++ b/.devcontainer/features/spec-kit/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# refer: https://github.com/github/spec-kit
+
+# export DEBIAN_FRONTEND=noninteractive
+
+echo "################ Pip Update"
+python3 -m pip install --upgrade pip
+
+pip install uv
+
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+uv tool update-shell
+echo "✅ Install Spec Kit"
+
+### End of File


### PR DESCRIPTION

This PR adds two new devcontainer features and updates the devcontainer configuration:

- **Gemini feature**: Installs @google/gemini-cli via npm
- **Spec Kit feature**: Installs the GitHub spec-kit CLI tool via uv/pip
- **devcontainer.json**: Registers both new features alongside the existing opencode feature
- **opencode feature**: Removes unnecessary `sudo` prefix from apt-get commands (runs as root in container)
